### PR TITLE
ci: only run dockerbuild on amd64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,13 +81,13 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
 
     - name: Build Docker image
       uses: docker/build-push-action@v6
       with:
         context: .
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: false
         tags: test-image:latest
         cache-from: type=gha


### PR DESCRIPTION
Docker builds take a lot of time for arm64.
We verify most of the issues in the Dockerfile with running on amd64 so there is not that much value in running it in CI